### PR TITLE
Add BaseResource, adjust code paths to work with BaseResource types

### DIFF
--- a/icekube/icekube.py
+++ b/icekube/icekube.py
@@ -11,7 +11,7 @@ from icekube.kube import (
     kube_version,
 )
 from icekube.models import Cluster, Signer
-from icekube.models.base import Resource
+from icekube.models.base import BaseResource, Resource
 from icekube.neo4j import create, find, get, get_driver
 from neo4j import BoltDriver
 from tqdm import tqdm
@@ -63,23 +63,57 @@ def enumerate_resource_kind(
             cmd, kwargs = create(resource)
             session.run(cmd, **kwargs)
 
+            current = resource
+            next_recurse = []
+
+            if hasattr(current, "referenced_objects"):
+                next_recurse.extend(current.referenced_objects)
+
+            # Recurse into nested objects and calls out to
+            # neo4j to create the object if it doesn't exist
+            while len(next_recurse) > 0:
+                next_objs = []
+                for obj in next_recurse:
+                    if obj is None:
+                        # Will happen when a resource that can contain
+                        # a nested object didn't have it specified
+                        continue
+
+                    if hasattr(obj, "referenced_objects"):
+                        next_objs.extend(obj.referenced_objects)
+
+                    cmd, kwargs = create(obj)
+                    session.run(cmd, **kwargs)
+
+                next_recurse = next_objs
+
 
 def relationship_generator(
     driver: BoltDriver,
     initial: bool,
-    resource: Resource,
+    resource: BaseResource,
 ):
     with driver.session() as session:
         logger.info(f"Generating relationships for {resource}")
         for source, relationship, target in resource.relationships(initial):
-            if isinstance(source, Resource):
+            if isinstance(source, (BaseResource, Resource)):
                 src_cmd, src_kwargs = get(source, prefix="src")
+            elif source is None:
+                # Can happen when the source type defined in the relationship
+                # is None, usually due to a bug in the code. Same for the target.
+                logger.warn(f"Source for resource {resource} in relationship is None")
+                continue
             else:
                 src_cmd = source[0].format(prefix="src")
                 src_kwargs = {f"src_{key}": value for key, value in source[1].items()}
 
-            if isinstance(target, Resource):
+            if isinstance(target, (BaseResource, Resource)):
                 dst_cmd, dst_kwargs = get(target, prefix="dst")
+            elif target is None:
+                logger.warn(
+                    f"Destination for resource {resource} in relationship is None"
+                )
+                continue
             else:
                 dst_cmd = target[0].format(prefix="dst")
                 dst_kwargs = {f"dst_{key}": value for key, value in target[1].items()}
@@ -95,37 +129,26 @@ def relationship_generator(
             session.run(cmd, kwargs)
 
 
-def generate_relationships(threaded: bool = False) -> None:
+def generate_relationships(threaded: bool = False, pass_total: int = 2) -> None:
     logger.info("Generating relationships")
-    logger.info("Fetching resources from neo4j")
     driver = get_driver()
-    resources = find()
-    logger.info("Fetched resources from neo4j")
     generator = partial(relationship_generator, driver, True)
 
-    if threaded:
-        with ThreadPoolExecutor() as exc:
-            exc.map(generator, resources)
-    else:
-        print("First pass for relationships")
-        for resource in tqdm(resources):
-            generator(resource)
-        print("")
+    pass_num = 0
+    while pass_num < pass_total:
+        pass_num += 1
+        logger.info("Fetching resources from neo4j")
+        resources = find()
+        logger.info("Fetched resources from neo4j")
 
-    # Do a second loop across relationships to handle objects created as part
-    # of other relationships
-
-    resources = find()
-    generator = partial(relationship_generator, driver, False)
-
-    if threaded:
-        with ThreadPoolExecutor() as exc:
-            exc.map(generator, resources)
-    else:
-        print("Second pass for relationships")
-        for resource in tqdm(resources):
-            generator(resource)
-        print("")
+        if threaded:
+            with ThreadPoolExecutor() as exc:
+                exc.map(generator, resources)
+        else:
+            print(f"Generating relationships ({pass_num}/{pass_total})")
+            for resource in tqdm(resources):
+                generator(resource)
+            print("")
 
 
 def remove_attack_paths() -> None:

--- a/icekube/kube.py
+++ b/icekube/kube.py
@@ -175,6 +175,10 @@ def all_resources(
                 resource_kind.group,
                 resource_kind.kind,
             )
+
+            if not issubclass(resource_class, Resource):
+                continue
+
             if resource_kind.namespaced:
                 for ns in all_namespaces:
                     yield from resource_class.list(

--- a/icekube/models/__init__.py
+++ b/icekube/models/__init__.py
@@ -1,7 +1,6 @@
 from typing import List, Type
 
 from icekube.models.api_resource import APIResource
-
 from icekube.models.base import BaseResource, Resource  # noqa: F401
 from icekube.models.cluster import Cluster
 from icekube.models.clusterrole import ClusterRole

--- a/icekube/models/__init__.py
+++ b/icekube/models/__init__.py
@@ -1,7 +1,7 @@
 from typing import List, Type
 
 from icekube.models.api_resource import APIResource
-from icekube.models.base import BaseResource, Resource
+from icekube.models.base import BaseResource, Resource  # noqa: F401
 from icekube.models.cluster import Cluster
 from icekube.models.clusterrole import ClusterRole
 from icekube.models.clusterrolebinding import ClusterRoleBinding

--- a/icekube/models/__init__.py
+++ b/icekube/models/__init__.py
@@ -1,7 +1,8 @@
 from typing import List, Type
 
 from icekube.models.api_resource import APIResource
-from icekube.models.base import BaseResource, Resource  # noqa: F401
+# noqa: F401
+from icekube.models.base import BaseResource, Resource
 from icekube.models.cluster import Cluster
 from icekube.models.clusterrole import ClusterRole
 from icekube.models.clusterrolebinding import ClusterRoleBinding

--- a/icekube/models/__init__.py
+++ b/icekube/models/__init__.py
@@ -1,6 +1,7 @@
 from typing import List, Type
 
 from icekube.models.api_resource import APIResource
+
 # noqa: F401
 from icekube.models.base import BaseResource, Resource
 from icekube.models.cluster import Cluster

--- a/icekube/models/__init__.py
+++ b/icekube/models/__init__.py
@@ -1,7 +1,7 @@
 from typing import List, Type
 
 from icekube.models.api_resource import APIResource
-from icekube.models.base import Resource
+from icekube.models.base import BaseResource, Resource
 from icekube.models.cluster import Cluster
 from icekube.models.clusterrole import ClusterRole
 from icekube.models.clusterrolebinding import ClusterRoleBinding

--- a/icekube/models/__init__.py
+++ b/icekube/models/__init__.py
@@ -2,8 +2,7 @@ from typing import List, Type
 
 from icekube.models.api_resource import APIResource
 
-# noqa: F401
-from icekube.models.base import BaseResource, Resource
+from icekube.models.base import BaseResource, Resource  # noqa: F401
 from icekube.models.cluster import Cluster
 from icekube.models.clusterrole import ClusterRole
 from icekube.models.clusterrolebinding import ClusterRoleBinding

--- a/icekube/models/base.py
+++ b/icekube/models/base.py
@@ -190,7 +190,7 @@ class Resource(BaseResource):
                 values["plural"] = api_resource.name
 
         return values
-    
+
     @classmethod
     def get_kind_class(cls, apiVersion: str, kind: str) -> Type[Resource]:
         subclasses = {x.__name__: x for x in cls.__subclasses__()}

--- a/icekube/neo4j.py
+++ b/icekube/neo4j.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Generator, List, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from icekube.config import config
 from icekube.models import BaseResource, Cluster, Resource

--- a/icekube/neo4j.py
+++ b/icekube/neo4j.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Generator, List, Optional, Tuple, Type, TypeVar
+from typing import Any, Dict, Generator, List, Optional, Tuple, Type, TypeVar, Union
 
 from icekube.config import config
 from icekube.models import BaseResource, Cluster, Resource
@@ -25,8 +25,8 @@ def get_driver() -> BoltDriver:
     return driver
 
 
-def get_resource_kind(resource: BaseResource) -> str:
-    kind = resource.__class__.__name__
+def get_resource_kind(resource: Union[BaseResource, Type[BaseResource]]) -> str:
+    kind = resource.__class__.__name__ if type(resource) != type else resource.__name__
     if type(resource) == Resource or type(resource) == BaseResource:
         # If directly one of the base classes, use the kind from the API
         kind = resource.kind
@@ -84,7 +84,7 @@ def get(
     return cmd, kwargs
 
 
-def create(resource: Resource, prefix: str = "") -> Tuple[str, Dict[str, Any]]:
+def create(resource: BaseResource, prefix: str = "") -> Tuple[str, Dict[str, Any]]:
     cmd, kwargs = get(resource, "x", prefix)
 
     labels: List[str] = []
@@ -105,7 +105,7 @@ def find(
     resource: Optional[Type[BaseResource]] = None,
     raw: bool = False,
     **kwargs: str,
-) -> Generator[Resource, None, None]:
+) -> Generator[BaseResource, None, None]:
     labels = [f"{key}: ${key}" for key in kwargs.keys()]
     if resource is None:
         cmd = f"MATCH (x {{ {', '.join(labels)} }}) "

--- a/icekube/neo4j.py
+++ b/icekube/neo4j.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, Generator, List, Optional, Tuple, Type, TypeVar
 
 from icekube.config import config
-from icekube.models import Cluster, BaseResource, Resource
+from icekube.models import BaseResource, Cluster, Resource
 from neo4j import BoltDriver, GraphDatabase
 from neo4j.io import ServiceUnavailable
 


### PR DESCRIPTION
#### Commit Log  

* Add BaseResource, adjust code paths to work with BaseResource types
* Added utility method to get kind from resource, respecting any potential BaseResource that has its `kind` field specified by any inheriting objects
* Refactored looping code to be configurable, for potential future need to re-loop after initial relationship creation

### Summary
This PR adds a new base class for referencing any sub-objects defined in the spec of a `Resource`. This is so that we can map relationships between the `Resource` and any type that has a relationship to the `Resource` (e.g. DEFINES, USES, CONSUMES, REFERENCES)

An example of a type that can be represented using `BaseResource` is [SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#secretreference-v1-core) - It doesn't appear as an API resource within K8s, but tracking the definition of the SecretReference object can be useful in tracing where references originate from in a more generic and composable way.

I'm open to discussion for any concerns or alternative implementations we might want to pursue. Some important things to note is that we expect some `BaseResource` types to define their own `apiVersion` and `kind` fields, since some objects use those fields to determine which object K8s should refer to (e.g. [ObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#objectreference-v1-core)), so including `apiVersion` and `kind` in the `BaseResource` class might be premature or not a wise move